### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,34 +1,26 @@
 services:
-  ollama:
-    volumes:
-      - ollama:/root/.ollama
-    container_name: ollama
-    pull_policy: always
-    tty: true
-    restart: unless-stopped
-    image: ollama/ollama:${OLLAMA_DOCKER_TAG-latest}
-
   open-webui:
     build:
       context: .
       args:
-        OLLAMA_BASE_URL: '/ollama'
+        BASE_IMAGE: "nvidia/cuda:12.1.1-base-ubuntu22.04"
       dockerfile: Dockerfile
-    image: ghcr.io/open-webui/open-webui:${WEBUI_DOCKER_TAG-main}
+    image: edit-open-webui
     container_name: open-webui
     volumes:
       - open-webui:/app/backend/data
-    depends_on:
-      - ollama
     ports:
-      - ${OPEN_WEBUI_PORT-3000}:8080
+      - "3000:8080"
     environment:
-      - 'OLLAMA_BASE_URL=http://ollama:11434'
-      - 'WEBUI_SECRET_KEY='
-    extra_hosts:
-      - host.docker.internal:host-gateway
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     restart: unless-stopped
 
 volumes:
-  ollama: {}
-  open-webui: {}
+  open-webui:


### PR DESCRIPTION
after building the image, had remove the container and run it with --network=host flag mentioned in open-webui github page - Troubleshooting. that is, ran it with:
docker run -d --gpus all -p 3000:8080 -v open-webui:/app/backend/data --name open-webui edit-open-webui this way, the the ui is at localhost:8080 now, not 3000. finally, had to change ollama api connection to http://localhost:11434 in the open-webui settings - admin settings - connections